### PR TITLE
Change some part of BFS

### DIFF
--- a/entry/main.cpp
+++ b/entry/main.cpp
@@ -4,6 +4,7 @@
 
 #include "Airport.h"
 #include "Graph.h"
+#include "graphTraversal/BFS.h"
 #include "utils.h"
 
 using namespace std;
@@ -11,10 +12,11 @@ using namespace std;
 void example1();
 void example2();
 void example3();
+void example4();
 
 int main()
 {
-    example2();
+    example4();
     return 0;
 }
 
@@ -135,4 +137,19 @@ void example3() {
         cout << "[end]\n";
     }
     cout << "\n-----------------------------------------------------\n\n";
+}
+
+void example4() {
+    string airportFileName = "../data/airports.dat";
+    string routeFileName = "../data/routes.dat";
+    string airlineFileName = "../data/airlines.dat";
+
+    Graph g(airportFileName, routeFileName, airlineFileName);
+
+    BFS bfs(&g, 0);
+
+    for (auto curr : bfs) {
+        // curr is a pointer of airport
+        cout << "current airport : " << curr->name_ << " , idx = " << curr->index_ << endl;
+    }
 }

--- a/src/Graph.cpp
+++ b/src/Graph.cpp
@@ -44,22 +44,33 @@ int Graph::getSize() {
     return size_;
 }
 
-// helper functions
+vector<Airport*> Graph::getNeighbors(int idx) {
+    vector<Airport*> neighbors;
 
-/**
- * Calculate the weights between two airpots
- *
- * @param flight current flight
- *
- * @return weight of current flight
- */
-double Graph::_calcWeight(const Flight& flight) {
+    for (const auto& curr : flights_[idx]) {
+        neighbors.push_back(index_to_airpot_[curr.first]);
+    }
+
+    return neighbors;
+}
+
+// helper functions
+long double Graph::_calcWeight(const Flight& flight) {
     // find airports using id
     Airport* source = id_to_airpot_[flight.getSourceId()];
     Airport* destination = id_to_airpot_[flight.getDestinationId()];
 
     // do the calculate
     return calcDistance(source->latitude_, source->longitude_, destination->latitude_, destination->longitude_) + flight.getStops() * 50;
+}
+
+long double Graph::_calcWeight(int source_idx, int destination_idx) {
+    // find airports using id
+    Airport* source = index_to_airpot_[source_idx];
+    Airport* destination = index_to_airpot_[destination_idx];
+
+    // do the calculate
+    return calcDistance(source->latitude_, source->longitude_, destination->latitude_, destination->longitude_);
 }
 
 /**
@@ -167,4 +178,20 @@ void Graph::buildFloydWarshall() {
 
     // and setup
     floyd_warshall_ = FloydWarshall(size_, weight);
+}
+
+pair<int, int> Graph::foo() {
+    int max_nei = -1;
+    int max_idx = -1;
+    int curr_nei;
+    int idx = 0;
+    for (const auto& curr : flights_) {
+        curr_nei = curr.size();
+        if (curr_nei > max_nei) {
+            max_nei = curr_nei;
+            max_idx = idx;
+        }
+        idx++;
+    }
+    return pair<int, int>(max_idx, max_nei);
 }

--- a/src/Graph.cpp
+++ b/src/Graph.cpp
@@ -179,19 +179,3 @@ void Graph::buildFloydWarshall() {
     // and setup
     floyd_warshall_ = FloydWarshall(size_, weight);
 }
-
-pair<int, int> Graph::foo() {
-    int max_nei = -1;
-    int max_idx = -1;
-    int curr_nei;
-    int idx = 0;
-    for (const auto& curr : flights_) {
-        curr_nei = curr.size();
-        if (curr_nei > max_nei) {
-            max_nei = curr_nei;
-            max_idx = idx;
-        }
-        idx++;
-    }
-    return pair<int, int>(max_idx, max_nei);
-}

--- a/src/Graph.h
+++ b/src/Graph.h
@@ -9,9 +9,6 @@
 #include "FloydWarshall.h"
 #include "utils.h"
 
-#include <utility>
-using std::pair;
-
 using std::vector;
 using std::string;
 using std::unordered_map;
@@ -112,8 +109,6 @@ class Graph {
             floyd_warshall_ = other.floyd_warshall_;
             flights_ = other.flights_;
         }
-
-        pair<int, int> foo();
 
     private:
         // Define infinite

--- a/src/Graph.h
+++ b/src/Graph.h
@@ -9,6 +9,9 @@
 #include "FloydWarshall.h"
 #include "utils.h"
 
+#include <utility>
+using std::pair;
+
 using std::vector;
 using std::string;
 using std::unordered_map;
@@ -54,14 +57,51 @@ class Graph {
         vector<string> getShortestPath(const vector<string>& airports);
 
         /**
-         * overload operator = so that graph can be used as input to traversal.
-        */
+         * @brief Get Airport using index
+         * 
+         * @param idx index of airport
+         * @return Airport 
+         */
+        Airport* getAirport(int idx);
 
-        Airport getAirport(int idx);
-
+        /**
+         * @brief Get the size of graph
+         * 
+         * @return number of nodes 
+         */
         int getSize();
 
+        /**
+         * @brief Get the Neighbors of airport
+         * 
+         * @param idx index of that airport
+         * @return neighbors
+         */
+        vector<Airport*> getNeighbors(int idx);
+        
+        // helper functions
+        /**
+         * @brief Calculate the weights between two airpots
+         *
+         * @param flight current flight
+         *
+         * @return weight of current flight
+         */
+        long double _calcWeight(const Flight& flight);
 
+        /**
+         * @brief Calculate the weights between two airpots using index
+         *
+         * @param source index of source
+         * @param destination index of destination
+         *
+         * @return weight
+         */
+        long double _calcWeight(int source_idx, int destination_idx);
+
+        /**
+         * @brief overload operator = so that graph can be used as input to traversal.
+         */
         void operator=(const Graph &other) {
             size_ = other.size_;
             INF = 1e8;
@@ -72,6 +112,8 @@ class Graph {
             floyd_warshall_ = other.floyd_warshall_;
             flights_ = other.flights_;
         }
+
+        pair<int, int> foo();
 
     private:
         // Define infinite
@@ -86,9 +128,6 @@ class Graph {
         vector<unordered_map<int, Flight>> flights_;
 
         FloydWarshall floyd_warshall_;
-
-        // helper functions
-        double _calcWeight(const Flight& flight);
 
         void buildAirpots(const std::string& airportFileName);
         void buildFlights(const std::string& routeFileName);

--- a/src/graphTraversal/BFS.cpp
+++ b/src/graphTraversal/BFS.cpp
@@ -1,5 +1,11 @@
 #include "BFS.h"
 
+/**
+ * Initializes a breadth-first ImageTraversal on a given graph, starting at `start`
+ * 
+ * @param graph The graph this BFS is going to traverse
+ * @param start The start index of this BFS
+ */
 BFS::BFS(Graph* graph, int start) {
     graph_ = graph;
     start_ = start;
@@ -10,14 +16,23 @@ BFS::BFS(Graph* graph, int start) {
     visited_[start] = true;
 }
 
+/**
+ * Returns an iterator for the traversal starting at the first point.
+ */
 GraphTraversal::Iterator BFS::begin() {
     return GraphTraversal::Iterator(this, start_, graph_);
 }
 
+/**
+ * Returns an iterator for the traversal one past the end of the traversal.
+ */
 GraphTraversal::Iterator BFS::end() {
     return GraphTraversal::Iterator();
 }
 
+/**
+ * Adds a index for the traversal to visit in the future.
+ */
 void BFS::add(int idx) {
     if (visited_[idx]) return;
 
@@ -25,23 +40,38 @@ void BFS::add(int idx) {
     visited_[idx] = true;
 }
 
+/**
+ * Removes and returns the current index in the traversal.
+ */
 int BFS::pop() {
     int temp = peek();
 
     queue_.pop();
-    
+
     return temp;
 }
 
+/**
+ * Returns the current index in the traversal.
+ *  (-1 for NULL)
+ */
 int BFS::peek() const {
     if (queue_.empty()) return -1;
     return queue_.front();
 }
 
+/**
+ * Returns true if the traversal is empty.
+ */
 bool BFS::empty() const {
     return queue_.empty();
 }
 
+/**
+ * Return true if index is visited
+ * 
+ * @param idx the index to check
+ */
 bool BFS::isVisited(int idx) {
     return visited_[idx];
 }

--- a/src/graphTraversal/BFS.cpp
+++ b/src/graphTraversal/BFS.cpp
@@ -1,17 +1,17 @@
 #include "BFS.h"
 
-BFS::BFS(Graph& graph, int start) {
+BFS::BFS(Graph* graph, int start) {
     graph_ = graph;
     start_ = start;
-    queue_.push(graph_.getAirport(start));
 
-    visited.resize(graph_.getSize(), false);
-    visited[start] = true;
+    queue_.push(start);
+
+    visited_.resize(graph_->getSize(), false);
+    visited_[start] = true;
 }
 
 GraphTraversal::Iterator BFS::begin() {
-    GraphTraversal* bfs = new BFS(graph_, start_);
-    return GraphTraversal::Iterator(bfs, start_, graph_);
+    return GraphTraversal::Iterator(this, start_, graph_);
 }
 
 GraphTraversal::Iterator BFS::end() {
@@ -19,21 +19,22 @@ GraphTraversal::Iterator BFS::end() {
 }
 
 void BFS::add(int idx) {
-    Airport airport = graph_.getAirport(idx);
-    visited[idx] = true;
-    queue_.push(airport);
+    if (visited_[idx]) return;
+
+    queue_.push(idx);
+    visited_[idx] = true;
 }
 
-Airport BFS::pop() {
-    Airport temp = peek();
-    /**
-     * @todo Not sure whether airport is treated as visited after pushing to queue or popping from queue.
-    */
+int BFS::pop() {
+    int temp = peek();
+
     queue_.pop();
+    
     return temp;
 }
 
-Airport BFS::peek() const {
+int BFS::peek() const {
+    if (queue_.empty()) return -1;
     return queue_.front();
 }
 
@@ -42,5 +43,5 @@ bool BFS::empty() const {
 }
 
 bool BFS::isVisited(int idx) {
-    return visited[idx];
+    return visited_[idx];
 }

--- a/src/graphTraversal/BFS.h
+++ b/src/graphTraversal/BFS.h
@@ -10,29 +10,29 @@
 class BFS: public GraphTraversal 
 {
     public:
-    /**
-     * @param graph The graph to be traversed
-     * @param start The starting Airport's index
-    */
-        BFS(Graph& graph, int start);
+        /**
+         * @param graph The graph to be traversed
+         * @param start The starting Airport's index
+        */
+        BFS(Graph* graph, int start);
 
         GraphTraversal::Iterator begin();
         GraphTraversal::Iterator end();
 
         void add(int idx);
-        Airport pop();
-        Airport peek() const;
+        int pop();
+        int peek() const;
         bool empty() const;
 
         /**
          * @param idx The index of Airport to be verified
         */
         bool isVisited(int idx);
-        Airport get_start;
 
     private:
-        Graph graph_;
+        // private members
+        Graph* graph_;
         int start_;
-        std::queue<Airport> queue_;
-        std::vector<bool> visited;
+        std::queue<int> queue_;
+        std::vector<bool> visited_;
 };

--- a/src/graphTraversal/GraphTraversal.cpp
+++ b/src/graphTraversal/GraphTraversal.cpp
@@ -33,6 +33,7 @@ GraphTraversal::Iterator & GraphTraversal::Iterator::operator++() {
 }
 
 Airport* GraphTraversal::Iterator::operator*() {
+    if (current_ == -1) return NULL;
     return graph_->getAirport(current_);
 }
 

--- a/src/graphTraversal/GraphTraversal.cpp
+++ b/src/graphTraversal/GraphTraversal.cpp
@@ -1,2 +1,81 @@
 #include "GraphTraversal.h"
 
+GraphTraversal::Iterator::Iterator() {
+    // empty, which is the end
+    traversal_ = NULL;
+    graph_ = NULL;
+}
+
+GraphTraversal::Iterator::Iterator(GraphTraversal* traversal, int start, Graph* graph) {
+    traversal_ = traversal;
+    start_ = start;
+    graph_ = graph;
+
+    // initialize the current iterator to top Node of the stack
+    current_ = traversal_->peek();
+}
+
+GraphTraversal::Iterator & GraphTraversal::Iterator::operator++() {
+    // check if it is the end
+    if (traversal_ != NULL && !traversal_->empty()) {
+        // if not
+        current_ = traversal_->pop();
+        // try add next vertexs
+        addNext(current_);
+        // after added, update the current point
+        if (!traversal_->empty()) current_ = traversal_->peek();
+    }
+    // reach the end
+    else
+        traversal_ = NULL;
+    
+    return *this;
+}
+
+Airport* GraphTraversal::Iterator::operator*() {
+    return graph_->getAirport(current_);
+}
+
+bool GraphTraversal::Iterator::operator!=(const GraphTraversal::Iterator &other) {
+    // init , which needs to check if either is empty
+    bool thisEmpty = false; 
+    bool otherEmpty = false;
+
+    if (traversal_ == NULL) 
+        thisEmpty = true;
+    if (other.traversal_ == NULL) 
+        otherEmpty = true;
+
+    if (!thisEmpty) 
+        thisEmpty = traversal_->empty();
+    if (!otherEmpty) 
+        otherEmpty = other.traversal_->empty();
+
+    // both empty then the traversals are equal, return false
+    if (thisEmpty && otherEmpty) 
+        return false; 
+    // both not empty then compare the traversals
+    if ((!thisEmpty) && (!otherEmpty)) 
+        return (traversal_ != other.traversal_);
+    // one is empty while the other is not, return true
+    return true;
+}
+
+// helper function
+void GraphTraversal::Iterator::addNext(int index) {
+    // init
+    vector<Airport*> data = graph_->getNeighbors(index);
+    vector<pair<long double, Airport*>> neighbors;
+
+    // add data to sort, shortest first
+    for (const auto& curr : data)
+        neighbors.push_back(pair<long double, Airport*>(graph_->_calcWeight(index, curr->index_), curr));
+    
+    std::sort(neighbors.begin(), neighbors.end(), [](pair<long double, Airport*> a, pair<long double, Airport*> b) {
+        return a.first < b.first;
+    });
+
+    for (const auto& curr : neighbors) {
+        traversal_->add(curr.second->index_);
+    }
+}

--- a/src/graphTraversal/GraphTraversal.h
+++ b/src/graphTraversal/GraphTraversal.h
@@ -1,7 +1,13 @@
 #pragma once
 
 #include <iterator>
+#include <vector>
+#include <utility>
+#include <algorithm>
 #include "../Graph.h"
+
+using std::vector;
+using std::pair;
 
 /**
  * A base class for traversal algorithms on graph.
@@ -13,26 +19,55 @@ class GraphTraversal {
          */
         class Iterator : std::iterator<std::forward_iterator_tag, Airport> {
             public:
+                /**
+                 * Default iterator constructor.
+                 */
                 Iterator();
 
+                /**
+                 * Three parameters constructor for Iterator class
+                 * 
+                 * @param traversal The traversal reference passed in
+                 * @param start The start point of Iterator
+                 * @param graph_ The graph reference passed in
+                 */
+                Iterator(GraphTraversal* traversal, int start, Graph* graph);
+
+                /**
+                 * Iterator increment opreator.
+                 *
+                 * Advances the traversal of the graph.
+                 */
                 Iterator & operator++();
-                Airport operator*();
+
+                /**
+                 * Iterator accessor opreator.
+                 *
+                 * Accesses the current airport in the ImageTraversal.
+                 * 
+                 * @return the current Airport
+                 */
+                Airport* operator*();
+
+                /**
+                 * Iterator inequality operator.
+                 *
+                 * Determines if two iterators are not equal.
+                 */
                 bool operator!=(const Iterator &other);
 
-                // member functions
-                Iterator(GraphTraversal* traversal, int start, Graph graph_);
 
             private:
                 // private members
-                Airport start_;
-                Airport current_;
+                int start_;
+                int current_;
                 
                 // references
                 GraphTraversal* traversal_;
                 Graph* graph_;
 
                 // helper function
-                void addNext(Airport node);
+                void addNext(int index);
         };
 
     /**
@@ -56,12 +91,12 @@ class GraphTraversal {
      * Remove and return the next point of the traversal
      * Virtual function. Derived class need to implement this
      */
-    virtual Airport pop() = 0;
+    virtual int pop() = 0;
     /**
      * Return but not remove the next point of the traversal
      * Virtual function. Derived class need to implement this
      */
-    virtual Airport peek() const = 0;
+    virtual int peek() const = 0;
     /**
      * To see if the traversal has no points left
      * Virtual function. Derived class need to implement this


### PR DESCRIPTION
Now can use `Iterator` to go through `Airport`s in breadth-first traversal.  

* Iterator return the pointer of current : `Airport*`
* change graph we pass in to `Graph*`, since our graph is large and no changes during traversal (save time for copy a new one, but if needed, we can still change back to `Graph`)
* And some other changes, such as from `Airport` to index, since we don't need that much information, save memory

usage:

    Graph g(airportFileName, routeFileName, airlineFileName);

    BFS bfs(&g, 0);

    for (const auto& curr : bfs) {
        cout << "current airport : " << curr->name_ << " , idx = " << curr->index_ << endl;
    }
